### PR TITLE
Feat: Improve image processing speed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,14 +3,14 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    kotlin("jvm") version "1.9.0"
-    kotlin("kapt") version "1.9.0"
-    id("org.graalvm.buildtools.native") version "0.9.23"
+    kotlin("jvm") version "1.9.10"
+    kotlin("kapt") version "1.9.10"
+    id("org.graalvm.buildtools.native") version "0.9.27"
     application
 }
 
 group = "com.github.secretx33"
-version = "0.1.2"
+version = "0.2"
 
 val javaVersion = 17
 
@@ -22,12 +22,12 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
-    implementation("org.apache.pdfbox:pdfbox:3.0.0-beta1")
+    implementation("org.apache.pdfbox:pdfbox:3.0.0")
     implementation("com.1stleg:jnativehook:2.1.0")
-    implementation("info.picocli:picocli:4.7.4")
-    kapt("info.picocli:picocli-codegen:4.7.4")
-    implementation("org.fusesource.jansi:jansi:2.4.0")
-    implementation(platform("io.arrow-kt:arrow-stack:1.2.0"))
+    implementation("info.picocli:picocli:4.7.5")
+    kapt("info.picocli:picocli-codegen:4.7.5")
+    implementation("org.fusesource.jansi:jansi:2.4.1")
+    implementation(platform("io.arrow-kt:arrow-stack:1.2.1"))
     implementation("io.arrow-kt:arrow-fx-coroutines")
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/secretx33/imagetopdf/model/PdfImage.kt
+++ b/src/main/kotlin/com/github/secretx33/imagetopdf/model/PdfImage.kt
@@ -1,14 +1,17 @@
 package com.github.secretx33.imagetopdf.model
 
 import org.apache.pdfbox.pdmodel.PDDocument
-import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
+import java.awt.Dimension
+import java.awt.image.BufferedImage
 import java.nio.file.Path
 
 data class PdfImage(
-    val image: PDImageXObject,
+    val image: BufferedImage,
     val fileName: Path,  // Only the name and extension
     val file: Path,      // The full path to the original image
     val width: Int,
     val height: Int,
     val document: PDDocument,
-)
+) {
+    val dimension = Dimension(width, height)
+}


### PR DESCRIPTION
This is a major improvement for ImageToPdf. The speed improvement is immediate and up to x8 faster image conversions across the board. Plus, the software now uses much less memory than before, better handling conversion of big images.

## Performance tests

Here are some simple tests that I ran.

| Total Size | Images | Previous (v0.1.2) | This (v0.2) |
| - | - | - | - |
| 8MB | 1 | 4s |  0.7s |
| 65MB | 4 | 15s | 1.8s |
| 110MB | 6 | 16.2s | 2.2s |
| 315MB | 14  | 33.1s | 4.6s |

_Total Size is the size of all images combined._